### PR TITLE
Replaced 'grep' by 'find' on windows

### DIFF
--- a/lib/find.js
+++ b/lib/find.js
@@ -17,7 +17,7 @@ function listeners (port, done) {
 
   if (process.platform === 'win32') {
     sudo = 'runas /noprofile /user:Administrator';
-    command = 'netstat -n -a -o | grep -i listening | grep :' + settings.port;
+    command = 'netstat -n -a -o | find /i "listening" | find ":' + settings.port + ' "';
     rpid = /\d+$/gm;
   } else {
     sudo = 'sudo';


### PR DESCRIPTION
Also added a space after the port number searched string. This is to avoid matching for example :80 and :8000 together.
