### PR TITLE
Fixed: correctly interpret grep return code 1

### DIFF
--- a/lib/find.js
+++ b/lib/find.js
@@ -21,7 +21,10 @@ function listeners (port, done) {
     rpid = /\d+$/gm;
   } else {
     sudo = 'sudo';
-    command = 'lsof -i tcp:' + settings.port + ' | grep -i listen';
+    command = '( lsof -i tcp:' + settings.port + ' | grep -i listen ) ; rc=$? ; if (( rc >= 2 )) ; then exit $rc ; else exit 0 ; fi'; /*
+      grep exits with return code 1 if it did not match any input lines.
+      If grep fails, then it exists with a return code >= 2.
+      */
     rpid = / \d+ (?=(.*)IPv\d)/gm;
   }
 


### PR DESCRIPTION
Fixed: correctly interpret grep return code 1 not to indicate failure of grep for non Win32 platforms.